### PR TITLE
[devops:bot] update deps in nix/sources.json (from: launch-deversifi@2fe7a3f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "fix-yarn2nix-for-nix-2.5-6",
+        "branch": "fix-yarn2nix-for-nix-2.5-6_29769d2a1390d294469bcc6518f17931953545e1",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "deversifi",
         "repo": "nixpkgs",
-        "rev": "f39d74093d5afd722c39dab844a7c34eae56921f",
-        "sha256": "1npjqgbx6dr5sd1gf7y90dviggmm8y8fppw5djypjik40rwn896m",
+        "rev": "41b5736e8a7584ddf096a05b8b3afaf2a75e66fe",
+        "sha256": "0jg0jvc1acw9f71v0c7yyp13c37wjz2slnb3jd1d066g5vz3b3qi",
         "type": "tarball",
-        "url": "https://github.com/deversifi/nixpkgs/archive/f39d74093d5afd722c39dab844a7c34eae56921f.tar.gz",
+        "url": "https://github.com/deversifi/nixpkgs/archive/41b5736e8a7584ddf096a05b8b3afaf2a75e66fe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
update nix refernces for `launch-deversifi` and|or `nixpkgs` to match https://github.com/rhinofi/launch-deversifi/blob/2fe7a3fd74c4d6afc09249741fd2be97598fb48e/nix/sources.json